### PR TITLE
Added support for legacy Helm chart repositories

### DIFF
--- a/helm/dagger.json
+++ b/helm/dagger.json
@@ -1,5 +1,6 @@
 {
   "name": "helm",
+  "engineVersion": "v0.14.0",
   "sdk": "go",
-  "engineVersion": "v0.14.0"
+  "source": "."
 }

--- a/helm/main.go
+++ b/helm/main.go
@@ -137,7 +137,7 @@ func (h *Helm) PackagePush(
 	}
 
 	if chartExists {
-		return false, fmt.Errorf("Chart already exists on server.")
+		return false, nil
 	}
 
 	c, err = c.WithExec([]string{"helm", "dependency", "update", "."}).

--- a/helm/main.go
+++ b/helm/main.go
@@ -152,15 +152,15 @@ func (h *Helm) PackagePush(
 	if useNonOciHelmRepo {
 		curlCmd := []string{
 			`curl --variable %REGISTRY_USERNAME`,
-			     `--variable %REGISTRY_PASSWORD`,
-				 `--expand-user "{{REGISTRY_USERNAME}}:{{REGISTRY_PASSWORD}}"`,
-				 `-T ${PKGFILE}`,
-				 opts.getChartFqdn(name),
+			`--variable %REGISTRY_PASSWORD`,
+			`--expand-user "{{REGISTRY_USERNAME}}:{{REGISTRY_PASSWORD}}"`,
+			`-T`,
+			pkgFile,
+			opts.getRepoFqdn() + "/",
 		}
 
 		c, err = c.
 			WithEnvVariable("REGISTRY_USERNAME", opts.Username).
-			WithEnvVariable("PKGFILE", pkgFile).
 			WithSecretVariable("REGISTRY_PASSWORD", opts.Password).
 			WithExec([]string{"sh", "-c", strings.Join(curlCmd, " ")}).
 			Sync(ctx)
@@ -276,7 +276,7 @@ func (h *Helm) doesChartExistOnRepo(
 			 `--expand-user "{{REGISTRY_USERNAME}}:{{REGISTRY_PASSWORD}}"`,
 			 opts.getChartFqdn(pkgFile),
 			 `--output /dev/null`,
-			 `--silent -Iw '%{http_code}`,
+			 `--silent -Iw '%{http_code}'`,
 	}
 
 	httpCode, err := c.

--- a/helm/main.go
+++ b/helm/main.go
@@ -269,6 +269,7 @@ func (h *Helm) doesChartExistOnRepo(
 	}
 	// else non-OCI
 	pkgFile := fmt.Sprintf("%s-%s.tgz", name, version)
+	// Do a GET of the chart but with response headers only so we do not download the chart
 	curlCmd := []string{
 		`curl --variable %REGISTRY_USERNAME`,
 			 `--variable %REGISTRY_PASSWORD`,
@@ -280,7 +281,6 @@ func (h *Helm) doesChartExistOnRepo(
 
 	httpCode, err := c.
 		WithEnvVariable("REGISTRY_USERNAME", opts.Username).
-		WithEnvVariable("PKGFILE", pkgFile).
 		WithSecretVariable("REGISTRY_PASSWORD", opts.Password).
 		WithExec([]string{"sh", "-c", strings.Join(curlCmd, " ")}).
 		Stdout(ctx)

--- a/helm/main.go
+++ b/helm/main.go
@@ -84,7 +84,7 @@ func (h *Helm) Version(
 //		--username $REGISTRY_HELM_USER \
 //		--password env:REGISTRY_HELM_PASSWORD \
 //		--directory ./examples/testdata/mychart/ \
-//		--use-non-oci-helm-repo true
+//		--use-non-oci-helm-repo=true
 func (h *Helm) PackagePush(
 	// method call context
 	ctx context.Context,

--- a/helm/main.go
+++ b/helm/main.go
@@ -58,7 +58,7 @@ func (h *Helm) Version(
 	return strings.TrimSpace(version), nil
 }
 
-// Packages and pushes a Helm chart to a specified OCI-compatible registry with authentication.
+// Packages and pushes a Helm chart to a specified OCI-compatible (by default) registry with authentication.
 //
 // Returns true if the chart was successfully pushed, or false if the chart already exists, with error handling for push failures.
 //
@@ -70,6 +70,16 @@ func (h *Helm) Version(
 //	  --username $REGISTRY_HELM_USER \
 //	  --password env:REGISTRY_HELM_PASSWORD \
 //	  --directory ./examples/testdata/mychart/
+//
+// Example usage for pushing to a legacy (non-OCI) Helm repository:
+//
+//	dagger call package-push \
+//	  --registry registry.puzzle.ch \
+//	  --repository helm \
+//	  --username $REGISTRY_HELM_USER \
+//	  --password env:REGISTRY_HELM_PASSWORD \
+//	  --directory ./examples/testdata/mychart/ \
+//        --oci false
 func (h *Helm) PackagePush(
 	// method call context
 	ctx context.Context,
@@ -83,11 +93,15 @@ func (h *Helm) PackagePush(
 	username string,
 	// registry login password
 	password *dagger.Secret,
+	// Set to false to use legacy Helm repository
+	// +optional
+	// +default=true
+	oci bool,
 ) (bool, error) {
 	opts := PushOpts{
 		Registry:   registry,
 		Repository: repository,
-		Oci:        true,
+		Oci:        oci,
 		Username:   username,
 		Password:   password,
 	}


### PR DESCRIPTION
This change adds support for legacy (non-OCI) Helm chart repositories in the least-disruptive way to the existing API. 

I will add unit tests if the maintainers are initially okay with this. If not, I could instead refactor the code to add a separate method with a different name and the different signature.

If not interested in adding legacy Helm repo support at all, just say so and I'll close my PR. 

Thanks for your consideration!

Russ